### PR TITLE
Update README with API key configuration

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,10 @@ This project provides examples guided by tests for developers who are interested
    * Shows embedding-based semantic search capabilities.
 2. [BasicRAGTest](src/test/kotlin/aibytests/openai/BasicRAGTest.kt)
    * Set up simple documents in memory for clarity
-   * Search for a relevant document using the query. 
+   * Search for a relevant document using the query.
    * Generate a response with the retrieved content.
+
+### Configuration
+* Tests require an OpenAI API key.
+* Set the environment variable `OPENAI_API_KEY` (or `openai_api_key`) or edit `src/main/resources/application.yml` to provide the key.
 


### PR DESCRIPTION
## Summary
- document how to provide an OpenAI API key for running tests

## Testing
- `sh ./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686870bb285c832f9571ba460daa3b98